### PR TITLE
Respect FRONTEND_URL in CORS config

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,14 +30,18 @@ app.use(cors({
     }
     
     // In production, check against allowed origins
-    const allowedOrigins = [
+    const allowedOrigins = [];
+    if (process.env.FRONTEND_URL) {
+      allowedOrigins.push(process.env.FRONTEND_URL);
+    }
+    allowedOrigins.push(
       'https://repspheres.netlify.app',
       'https://repspheres.com',
       'http://localhost:5176',
       'https://localhost:5176',
       'https://*.netlify.app',
       '*' // Allow all origins temporarily during testing
-    ];
+    );
     
     // Check if origin matches any allowed pattern
     const isAllowed = !origin || allowedOrigins.some(allowed => {


### PR DESCRIPTION
## Summary
- insert `process.env.FRONTEND_URL` into allowed CORS origins before hard-coded URLs

## Testing
- `npm run check:env` *(fails: Cannot find package 'dotenv')*