### PR TITLE
Respect FRONTEND_URL in CORS config

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@ app.use(cors({
     
     // In production, check against allowed origins
     const allowedOrigins = [
+      ...(process.env.FRONTEND_URL ? [process.env.FRONTEND_URL] : []),
       'https://repspheres.netlify.app',
       'https://repspheres.com',
       'http://localhost:5176',


### PR DESCRIPTION
## Summary
- insert `process.env.FRONTEND_URL` into allowed CORS origins before hard-coded URLs

## Testing
- `npm run check:env` *(fails: Cannot find package 'dotenv')*
