### PR TITLE
Remove unused model param from callLLM

### DIFF
--- a/index.js
+++ b/index.js
@@ -122,7 +122,7 @@ connectToSupabase().then(connected => {
 });
 
 // Call LLM endpoint using OpenRouter
-async function callLLM(model, prompt, llm_model) {
+async function callLLM(prompt, llm_model) {
   if (!process.env.OPENROUTER_API_KEY) {
     throw new Error('OpenRouter API key not configured');
   }
@@ -609,7 +609,7 @@ app.post('/task', async (req, res) => {
     });
 
     // Extract data from request body
-    const { model, prompt, llm_model, token } = req.body;
+    const { prompt, llm_model, token } = req.body;
     
     // Check if OpenRouter API key is configured
     if (!process.env.OPENROUTER_API_KEY) {
@@ -622,7 +622,7 @@ app.post('/task', async (req, res) => {
               content: "OpenRouter API key not configured. Please set the OPENROUTER_API_KEY environment variable."
             }
           }],
-          model: model || llm_model || "dummy-model",
+          model: llm_model || "dummy-model",
           prompt: prompt || "No prompt provided"
         }
       });
@@ -630,11 +630,11 @@ app.post('/task', async (req, res) => {
     
     try {
       // Call the LLM API
-      const llmResult = await callLLM(model, prompt, llm_model);
+      const llmResult = await callLLM(prompt, llm_model);
       
       // Try to log activity, but don't fail the request if logging fails
       try {
-        await logActivity({ model, prompt, llm_model }, llmResult);
+        await logActivity({ prompt, llm_model }, llmResult);
       } catch (logErr) {
         console.error('Error logging activity:', logErr);
       }
@@ -713,7 +713,7 @@ app.post('/webhook', async (req, res) => {
 
     try {
       // Route to LLM processing
-      const llmResult = await callLLM(null, prompt, null);
+      const llmResult = await callLLM(prompt, null);
       
       // Return a modified response structure compatible with webhook expectations
       return res.json({


### PR DESCRIPTION
## Summary
- drop unused `model` parameter from `callLLM`
- adjust `/task` and `/webhook` routes to use new signature
- return dummy model value using `llm_model`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run check:env` *(fails: cannot find module 'dotenv')*
- `node --check index.js`