### PR TITLE
Remove old vite URL env file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,7 @@ OPENAI_API_KEY=your_openai_api_key
 # Frontend URLs (for CORS)
 FRONTEND_URL=https://repspheres.com
 LOCAL_DEV=true # Set to false in production
+VITE_BACKEND_URL=http://localhost:3000/task
 
 # Auth Configuration (if using Google Auth)
 GOOGLE_CLIENT_ID=your_google_client_id

--- a/oldviteurl.env 
+++ b/oldviteurl.env 
@@ -1,1 +1,0 @@
-VITE_BACKEND_URL=http://localhost:3000/task


### PR DESCRIPTION
## Summary
- delete the obsolete `oldviteurl.env` file
- keep its value in `.env.example`

## Testing
- `npm run check:env` *(fails: Cannot find package 'dotenv')*