### PR TITLE
Add transcription routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,14 @@ A unified backend server for all Spheres applications, with centralized data sto
   - Body: `{ "model": "openai", "prompt": "your prompt here", "llm_model": "specific-model-if-needed" }`
   - Response: `{ success: true, llmResult: { /* LLM response */ } }`
 
+### Transcription Service
+- `POST /api/transcribe` - Upload an audio file for transcription and analysis. Send the file as `audio` (multipart/form-data) and include the user ID in the `x-user-id` header or as `userId`.
+- `GET /api/transcriptions` - List all transcriptions for a user.
+- `GET /api/transcriptions/:id` - Get a specific transcription record.
+- `DELETE /api/transcriptions/:id` - Delete a transcription.
+  
+See `TRANSCRIPTION_SERVICE_GUIDE.md` for full request and response examples.
+
 ## Deployment
 The service is configured to deploy to Render.com using the included `render.yaml` file.
 

--- a/TRANSCRIPTION_SERVICE_GUIDE.md
+++ b/TRANSCRIPTION_SERVICE_GUIDE.md
@@ -24,7 +24,7 @@ The service allows you to:
 
 **Parameters:**
 - `audio` (file): The audio file to transcribe
-- `userId` (string): The ID of the user
+- `userId` (string): The ID of the user (use the `x-user-id` header or include it as a form field)
 
 **Example Request:**
 ```bash


### PR DESCRIPTION
## Summary
- wire up `transcription_service.js` in `index.js`
- add /api/transcribe and transcription management routes
- document transcription routes in README
- clarify header usage in guide

## Testing
- `node --check index.js`
- `npm run test:transcription` *(fails: Cannot find package 'dotenv')*